### PR TITLE
Fixed the Issue #783 Multiple Operators in Calculator.

### DIFF
--- a/Projects/Calculator/js/script.js
+++ b/Projects/Calculator/js/script.js
@@ -43,7 +43,7 @@ for (item of buttons) {
             break;
 
             case 'x':
-                inputValue += '*';
+                inputValue = eval(inputValue) + '*';
                 result.innerHTML += '*';
             break;
                 

--- a/Projects/Calculator/js/script.js
+++ b/Projects/Calculator/js/script.js
@@ -93,6 +93,25 @@ for (item of buttons) {
                 inputValue = result.innerHTML;
             break;
             
+            case '+':
+                inputValue = eval(inputValue) + '+';
+                result.innerHTML += '+';
+            
+            break;
+            
+            case '-':
+                inputValue = eval(inputValue) + '-';
+                result.innerHTML += '-';
+
+            break;
+
+
+            case '/':
+                inputValue = eval(inputValue) + '/';
+                result.innerHTML += '/';
+            
+            break;
+            
             default :
             inputValue += buttonInput;
             result.innerHTML += buttonInput;


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

## 🛠️ Issue (#783 )

<!-- Example: #783  -->
Closes #783

# Description

I have solved the issue which is taking the multiple operators in the calculator. The Problem was in the input vale it was inputValue += '*' instead of inputValue = eval(inputValue) + '*';
So i have corrected it and added this change in all the other operators as well.

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just add x inside them for example [x] like this----->
- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] I have made this from my own

# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
<img width="1059" alt="Screenshot 2023-06-02 at 9 24 06 PM" src="https://github.com/TusharKesarwani/Front-End-Projects/assets/46023761/d126c90a-414f-499c-974f-eab8cbf90812">

Name - Abhishant Padam
SSOC Participant