### PR TITLE
Added Profile Link support in Contributors list

### DIFF
--- a/script.js
+++ b/script.js
@@ -89,14 +89,15 @@ fetch("https://api.github.com/repos/TusharKesarwani/Front-End-Projects/contribut
         // Extract the data for each contributor
         const contributors = data.map(contributor => ({
             username: contributor.login,
-            avatarUrl: contributor.avatar_url
+            avatarUrl: contributor.avatar_url,
+            profileUrl: contributor.html_url
         }));
 
         // Create and append HTML elements to display the contributors
         const contributorsList = document.querySelector("#contributors-list");
         contributors.forEach(contributor => {
             const li = document.createElement("li");
-            li.innerHTML = `<img src="${contributor.avatarUrl}" alt="${contributor.username}">`;
+            li.innerHTML = `<a href="${contributor.profileUrl}"><img src="${contributor.avatarUrl}" alt="${contributor.username}"></a>`;
             contributorsList.appendChild(li);
         });
     });


### PR DESCRIPTION
## 🛠️ Issue (Number)
Closes #782

# Description
Currently, as we can see, we have a pretty good landing page that briefly describes the Repo/projects and has a separate section for the contributors. But it doesn't has a link through which user can navigate to their profiles. So as per Issue #782 raised by me earlier, this PR fixes that issue.
As we fetch the contributor's detail from GitHub and then extract this information for each contributor so earlier we were fetching only the Profile image and username but in my version I have also fetched the profile link so that we can append it in HTML element, after this now whenever a user clicks on the contributor's profile pic he will be redirected to their profile.

## Type of change

<!----Please delete options that are not relevant. And to tick the check box just add x inside them for example [x] like this----->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# Checklist:

<!----Please delete options that are not relevant. And to tick the check box just put x inside them for example [x] like this----->
- [X] I have made this from my own
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings
- [X] The title of my pull request is a short description of the requested changes.


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK

# Current Version: 
![ezgif com-video-to-gif (2)](https://github.com/TusharKesarwani/Front-End-Projects/assets/111348926/9ab07b60-bb8d-4568-8541-b38164d1bd93)

# After changes: 
![ezgif com-video-to-gif (1)](https://github.com/TusharKesarwani/Front-End-Projects/assets/111348926/db0e604a-4524-41a0-9615-fc4839568c9c)


Thank You
