### PR TITLE
Added some functions for double move

### DIFF
--- a/Projects/chess/code.js
+++ b/Projects/chess/code.js
@@ -148,42 +148,50 @@ document.querySelectorAll('.box').forEach(item => {
         function whosTurn(toggle) {
 
             // PAWN
-
             if (item.innerText == `${toggle}pawn`) {
-                item.style.backgroundColor = 'pink'
-
+                item.style.backgroundColor = 'pink';
+            
                 if (tog % 2 !== 0 && aup < 800) {
-
                     if (document.getElementById(`b${a + 100}`).innerText.length == 0) {
-                        document.getElementById(`b${a + 100}`).style.backgroundColor = 'green'
+                        document.getElementById(`b${a + 100}`).style.backgroundColor = 'green';
                     }
-
+            
+                    // Check for the initial double move for black pawns (from row 2)
+                    if (aup < 300 && document.getElementById(`b${a + 200}`).innerText.length == 0) {
+                        document.getElementById(`b${a + 200}`).style.backgroundColor = 'green';
+                    }
+            
                     if (aside < 8 && document.getElementById(`b${a + 100 + 1}`).innerText.length !== 0) {
-                        document.getElementById(`b${a + 100 + 1}`).style.backgroundColor = 'green'
+                        document.getElementById(`b${a + 100 + 1}`).style.backgroundColor = 'green';
                     }
-
+            
                     if (aside > 1 && document.getElementById(`b${a + 100 - 1}`).innerText.length !== 0) {
-                        document.getElementById(`b${a + 100 - 1}`).style.backgroundColor = 'green'
-
+                        document.getElementById(`b${a + 100 - 1}`).style.backgroundColor = 'green';
                     }
                 }
-
+            
                 if (tog % 2 == 0 && aup > 100) {
-
                     if (document.getElementById(`b${a - 100}`).innerText.length == 0) {
-                        document.getElementById(`b${a - 100}`).style.backgroundColor = 'green'
+                        document.getElementById(`b${a - 100}`).style.backgroundColor = 'green';
                     }
+            
+                    // Check for the initial double move for white pawns (from row 7)
+                    if (aup > 500 && document.getElementById(`b${a - 200}`).innerText.length == 0) {
+                        document.getElementById(`b${a - 200}`).style.backgroundColor = 'green';
+                    }
+            
                     if (aside < 8 && document.getElementById(`b${a - 100 + 1}`).innerText.length !== 0) {
-                        document.getElementById(`b${a - 100 + 1}`).style.backgroundColor = 'green'
+                        document.getElementById(`b${a - 100 + 1}`).style.backgroundColor = 'green';
                     }
+            
                     if (aside > 1 && document.getElementById(`b${a - 100 - 1}`).innerText.length !== 0) {
-                        document.getElementById(`b${a - 100 - 1}`).style.backgroundColor = 'green'
-
+                        document.getElementById(`b${a - 100 - 1}`).style.backgroundColor = 'green';
                     }
                 }
-
-
             }
+            
+
+            
 
             // KING
 


### PR DESCRIPTION
Closes #1860 


![chessnew](https://github.com/TusharKesarwani/Front-End-Projects/assets/91870183/03217ed0-73a8-43e3-8c8d-91a491995bca)

# Description

In this chess project I Identified and solved an issue of movement pawns. Previously, the pawns could only move one block at a time but after fixing now  in the initial stage, the pawns' can move either 1 or 2 blocks at a time.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have made this from my own
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
